### PR TITLE
Refactor model import handling for Alembic

### DIFF
--- a/services/api/alembic/env.py
+++ b/services/api/alembic/env.py
@@ -8,7 +8,7 @@ from alembic import context
 import sys
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from app.db.base import Base  # noqa: E402
+from app.db.base import Base, import_models  # noqa: E402
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -19,6 +19,7 @@ config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
+import_models()
 target_metadata = Base.metadata
 
 

--- a/services/api/app/db/base.py
+++ b/services/api/app/db/base.py
@@ -6,20 +6,8 @@ class Base(DeclarativeBase):
     def __tablename__(cls) -> str:  # type: ignore[override]
         return cls.__name__.lower()
 
-
-# Import models here so Alembic can auto-detect
-from app.models import (  # noqa: F401
-    User,
-    Restaurant,
-    Branch,
-    Table,
-    Menu,
-    Category,
-    Item,
-    ItemOption,
-    Order,
-    OrderItem,
-    Recommendation,
-)
+def import_models() -> None:
+    """Import all SQLAlchemy models for metadata registration."""
+    from app import models  # noqa: F401
 
 

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -3,9 +3,16 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.core.config import settings
 from app.utils.rate_limit import RateLimitMiddleware
 from app.api.routers import auth, menu, items, cart, orders, ai, analytics, search
+from app.db.base import import_models
 
 
 app = FastAPI(title="Qlick API")
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    import_models()
+
 
 app.add_middleware(RateLimitMiddleware, limit=60, window_seconds=60)
 


### PR DESCRIPTION
## Summary
- remove eager model imports from `Base`
- add `import_models` helper and invoke on app startup and within Alembic env

## Testing
- `pip install requests -q`
- `pytest -q` *(fails: fixture 'method' not found)*
- `PYTHONPATH=. pytest tests/test_health.py -q`
- `python -m uvicorn app.main:app --reload`


------
https://chatgpt.com/codex/tasks/task_e_68baf63eeb34832182c5b4a400d73786